### PR TITLE
Derek furst/update requests version

### DIFF
--- a/hubmap_sdk/entitysdk.py
+++ b/hubmap_sdk/entitysdk.py
@@ -15,13 +15,14 @@ Create an instance of the class and give it the optional arguments 'token' and '
 
 class EntitySdk:
     def __init__(self, token=None, service_url='https://entity.api.hubmapconsortium.org/'):
+        self.header = {}
         self.token = token
         if service_url.endswith('/'):
             self.entity_url = service_url
         else:
             self.entity_url = service_url + '/'
         if token is not None:
-            self.header = {'Authorization': 'Bearer ' + self.token}
+            self.header['Authorization'] = f'Bearer {self.token}'
 
     # Using an instance of the EntitySdk class with appropriate authentication token, service_url as well as the
     # entity_type ('donor', 'sample', etc) and a dictionary containing the data for the new entity, an entity will be

--- a/hubmap_sdk/sdk_helper.py
+++ b/hubmap_sdk/sdk_helper.py
@@ -22,38 +22,41 @@ def make_entity(output):
 def make_request(method_type, instance, url, optional_argument=None, data=None):
     if optional_argument is None:
         optional_argument = ''
-    if data is None:
-        if instance.token is None:
-            if method_type == 'get':
-                r = requests.get(url + optional_argument)
-            if method_type == 'put':
-                r = requests.put(url + optional_argument)
-            if method_type == 'post':
-                r = requests.post(url + optional_argument)
+    try:
+        if data is None:
+            if instance.token is None:
+                if method_type == 'get':
+                    r = requests.get(url + optional_argument)
+                if method_type == 'put':
+                    r = requests.put(url + optional_argument)
+                if method_type == 'post':
+                    r = requests.post(url + optional_argument)
+            else:
+                if method_type == 'get':
+                    r = requests.get(url + optional_argument, headers=instance.header)
+                if method_type == 'put':
+                    r = requests.put(url + optional_argument, headers=instance.header)
+                if method_type == 'post':
+                    r = requests.post(url + optional_argument, headers=instance.header)
         else:
-            if method_type == 'get':
-                r = requests.get(url + optional_argument, headers=instance.header)
-            if method_type == 'put':
-                r = requests.put(url + optional_argument, headers=instance.header)
-            if method_type == 'post':
-                r = requests.post(url + optional_argument, headers=instance.header)
-    else:
-        if not isinstance(data, dict):
-            raise Exception("Data given must be a dictionary")
-        if instance.token is None:
-            if method_type == 'get':
-                r = requests.get(url + optional_argument, json=data)
-            if method_type == 'put':
-                r = requests.put(url + optional_argument, json=data)
-            if method_type == 'post':
-                r = requests.post(url + optional_argument, json=data)
-        else:
-            if method_type == 'get':
-                r = requests.get(url + optional_argument, headers=instance.header, json=data)
-            if method_type == 'put':
-                r = requests.put(url + optional_argument, headers=instance.header, json=data)
-            if method_type == 'post':
-                r = requests.post(url + optional_argument, headers=instance.header, json=data)
+            if not isinstance(data, dict):
+                raise Exception("Data given must be a dictionary")
+            if instance.token is None:
+                if method_type == 'get':
+                    r = requests.get(url + optional_argument, json=data)
+                if method_type == 'put':
+                    r = requests.put(url + optional_argument, json=data)
+                if method_type == 'post':
+                    r = requests.post(url + optional_argument, json=data)
+            else:
+                if method_type == 'get':
+                    r = requests.get(url + optional_argument, headers=instance.header, json=data)
+                if method_type == 'put':
+                    r = requests.put(url + optional_argument, headers=instance.header, json=data)
+                if method_type == 'post':
+                    r = requests.post(url + optional_argument, headers=instance.header, json=data)
+    except Exception:
+        raise HTTPException("Connection Error. Check that service url is correct in instance of Entity Class", 404)
     if r.status_code > 299:
         # if r.status_code == 401:
         #     raise Exception("401 Authorization Required. No Token or Invalid Token Given")

--- a/hubmap_sdk/searchsdk.py
+++ b/hubmap_sdk/searchsdk.py
@@ -6,13 +6,14 @@ from hubmap_sdk import sdk_helper
 class SearchSdk:
 
     def __init__(self, token=None, service_url="https://search.api.hubmapconsortium.org/"):
+        self.header = {}
         self.token = token
         if service_url.endswith('/'):
             self.search_url = service_url
         else:
             self.search_url = service_url + '/'
         if token is not None:
-            self.header = {'Authorization': 'Bearer ' + self.token}
+            self.header['Authorization'] = f'Bearer {self.token}'
 
     def assaytype(self, key):
         url = f"{self.search_url}assaytype"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 certifi==2021.10.8
 chardet==4.0.0
 idna==2.10
-requests==2.25.1
+requests>=2.22.0
 urllib3==1.26.7

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "certifi==2021.10.8",
         "chardet==4.0.0",
         "idna==2.10",
-        "requests==2.25.1",
+        "requests>=2.22.0",
         "urllib3==1.26.7"
     ],
     include_package_data=True,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="hubmap-sdk",
-    version="1.0.1",
+    version="1.0.2",
     author="Hubmap",
     author_email="api-developers@hubmapconsortium.org",
     description="Python Client Libary to use HuBMAP web services",


### PR DESCRIPTION
* Change attribute `self.header` in both EntitySdk and SearchSdk to be initialized to an empty dict regardless if a token is provided or not. 
* Added a single 'try' block around all of the requests inside _sdk_helper.make_request()_ to handle bad user provided service_url's. 
* Updated request library requirement in _setup.py_ and _requirements.txt_ to be `>=2.22.0` 
* Updated version number to 1.0.2